### PR TITLE
Fix reset logic and FlatList key handling

### DIFF
--- a/App.js
+++ b/App.js
@@ -47,6 +47,8 @@ export default function App() {
 
     const onReset = () => {
         setShowAppOptions(false);
+        setSelectedImage(null);
+        setPickedEmoji(null);
     };
 
     const onAddSticker = () => {

--- a/components/EmojiList.js
+++ b/components/EmojiList.js
@@ -16,6 +16,7 @@ export default function EmojiList({ onSelect, onCloseModal }) {
             horizontal
             showsHorizontalScrollIndicator={Platform.OS === 'web' ? true : false}
             data={emoji}
+            keyExtractor={(item, index) => index.toString()}
             contentContainerStyle={styles.listContainer}
             renderItem={({ item, index }) => {
                 return (
@@ -24,7 +25,7 @@ export default function EmojiList({ onSelect, onCloseModal }) {
                             onSelect(item);
                             onCloseModal();
                         }}>
-                        <Image source={item} key={index} style={styles.image} />
+                        <Image source={item} style={styles.image} />
                     </Pressable>
                 );
             }}


### PR DESCRIPTION
## Summary
- clear emoji and image when resetting the editor
- provide a keyExtractor for EmojiList items to remove warnings

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_684428db89cc83229c077435cc17b840